### PR TITLE
bugfix for 16-way with 16-bit dirty bit-maps

### DIFF
--- a/simulators/drrip/llc.cpp
+++ b/simulators/drrip/llc.cpp
@@ -53,7 +53,7 @@ void LLC::Init()
     m_dType_elemSz.resize(numMainDataTypes);
 
     m_tagArray = new intptr_t* [m_numSets];
-    m_dirty    = new uint8_t [m_numSets];
+    m_dirty    = new uint16_t [m_numSets];
     m_referenceCtr = new stat_t* [m_numSets];
     m_setLocks = new PIN_LOCK [m_numSets];
     m_rrpv  = new uint8_t* [m_numSets];
@@ -347,7 +347,7 @@ bool LLC::isCacheHit(intptr_t addr, int setID, bool isWrite, bool updateReplacem
             if (isWrite == true)
             {
                 //m_dirty[setID][way] = 1;
-                uint8_t mask = 1 << way;
+                uint16_t mask = 1 << way;
                 m_dirty[setID] = m_dirty[setID] | (mask);
             }
             m_referenceCtr[setID][way]++;
@@ -362,8 +362,8 @@ bool LLC::installNewLine(intptr_t addr, int setID, intptr_t &evictedAddr, bool i
     int index = getReplacementIndex(setID, setType, tid);
     //evictedAddr = m_tagArray[setID][index] * m_lineSz; //line to be kicked out
     evictedAddr = m_tagArray[setID][index]; //line to be kicked out
-    uint8_t mask = 1 << index;
-    uint8_t retVal = m_dirty[setID] & mask; 
+    uint16_t mask = 1 << index;
+    uint16_t retVal = m_dirty[setID] & mask; 
     assert(retVal == 0 || retVal == mask);
     if (evictedAddr == -1 * m_lineSz)
         assert(retVal == 0);

--- a/simulators/drrip/llc.h
+++ b/simulators/drrip/llc.h
@@ -56,7 +56,7 @@ class LLC
 
         /* tag store */
         intptr_t** m_tagArray; //[numSets][numWays];
-        uint8_t* m_dirty;      
+        uint16_t* m_dirty;      
         stat_t** m_referenceCtr; //keep track of no. of references between insertion & eviction
         PIN_LOCK* m_setLocks;  //[numSets]; //per-set lock
         

--- a/simulators/lru/llc.cpp
+++ b/simulators/lru/llc.cpp
@@ -52,7 +52,7 @@ void LLC::Init()
     m_dType_elemSz.resize(numMainDataTypes);
 
     m_tagArray = new intptr_t* [m_numSets];
-    m_dirty    = new uint8_t [m_numSets];
+    m_dirty    = new uint16_t [m_numSets];
     m_referenceCtr = new stat_t* [m_numSets];
     m_setLocks = new PIN_LOCK [m_numSets];
     m_lru_bits  = new uint8_t* [m_numSets];
@@ -339,7 +339,7 @@ bool LLC::isCacheHit(intptr_t addr, int setID, bool isWrite, bool updateReplacem
             if (isWrite == true)
             {
                 //m_dirty[setID][way] = 1;
-                uint8_t mask = 1 << way;
+                uint16_t mask = 1 << way;
                 m_dirty[setID] = m_dirty[setID] | (mask);
             }
             m_referenceCtr[setID][way]++;
@@ -354,8 +354,8 @@ bool LLC::installNewLine(intptr_t addr, int setID, intptr_t &evictedAddr, bool i
     int index = getReplacementIndex(setID, tid);
     //evictedAddr = m_tagArray[setID][index] * m_lineSz; //line to be kicked out
     evictedAddr = m_tagArray[setID][index]; //line to be kicked out
-    uint8_t mask = 1 << index;
-    uint8_t retVal = m_dirty[setID] & mask; 
+    uint16_t mask = 1 << index;
+    uint16_t retVal = m_dirty[setID] & mask; 
     assert(retVal == 0 || retVal == mask);
     if (evictedAddr == -1 * m_lineSz)
         assert(retVal == 0);

--- a/simulators/lru/llc.h
+++ b/simulators/lru/llc.h
@@ -56,7 +56,7 @@ class LLC
 
         /* tag store */
         intptr_t** m_tagArray; //[numSets][numWays];
-        uint8_t* m_dirty;      
+        uint16_t* m_dirty;      
         stat_t** m_referenceCtr; //keep track of no. of references between insertion & eviction
         PIN_LOCK* m_setLocks;  //[numSets]; //per-set lock
         

--- a/simulators/opt-ideal/llc.cpp
+++ b/simulators/opt-ideal/llc.cpp
@@ -55,7 +55,7 @@ void LLC::Init()
     m_dType_elemSz.resize(numMainDataTypes);
 
     m_tagArray = new intptr_t* [m_numSets];
-    m_dirty    = new uint8_t [m_numSets];
+    m_dirty    = new uint16_t [m_numSets];
     m_referenceCtr = new stat_t* [m_numSets];
     m_setLocks = new PIN_LOCK [m_numSets];
     PIN_MutexInit(&m_dstLock);
@@ -371,7 +371,7 @@ bool LLC::isCacheHit(intptr_t addr, int setID, bool isWrite, bool updateReplacem
             if (isWrite == true)
             {
                 //m_dirty[setID][way] = 1;
-                uint8_t mask = 1 << way;
+                uint16_t mask = 1 << way;
                 m_dirty[setID] = m_dirty[setID] | (mask);
             }
             m_referenceCtr[setID][way]++;
@@ -386,8 +386,8 @@ bool LLC::installNewLine(intptr_t addr, int setID, intptr_t &evictedAddr, bool i
     int index = getReplacementIndex(addr, setID, setType, tid);
     //evictedAddr = m_tagArray[setID][index] * m_lineSz; //line to be kicked out
     evictedAddr = m_tagArray[setID][index]; //line to be kicked out
-    uint8_t mask = 1 << index;
-    uint8_t retVal = m_dirty[setID] & mask;
+    uint16_t mask = 1 << index;
+    uint16_t retVal = m_dirty[setID] & mask;
     assert(retVal == 0 || retVal == mask);
     if (evictedAddr == -1 * m_lineSz)
         assert(retVal == 0);

--- a/simulators/opt-ideal/llc.h
+++ b/simulators/opt-ideal/llc.h
@@ -63,7 +63,7 @@ class LLC
 
         /* tag store */
         intptr_t** m_tagArray; //[numSets][numWays];
-        uint8_t* m_dirty;      
+        uint16_t* m_dirty;      
         stat_t** m_referenceCtr; //keep track of no. of references between insertion & eviction
         PIN_LOCK* m_setLocks;  //[numSets]; //per-set lock
         

--- a/simulators/popt-8b/llc.cpp
+++ b/simulators/popt-8b/llc.cpp
@@ -61,7 +61,7 @@ void LLC::Init()
     m_dType_elemSz.resize(numMainDataTypes);
      
     m_tagArray = new intptr_t* [m_numSets];
-    m_dirty    = new uint8_t [m_numSets];
+    m_dirty    = new uint16_t [m_numSets];
     m_referenceCtr = new stat_t* [m_numSets];
     m_setLocks = new PIN_LOCK [m_numSets];
     PIN_MutexInit(&m_dstLock);
@@ -432,7 +432,7 @@ bool LLC::isCacheHit(intptr_t addr, int setID, bool isWrite, bool updateReplacem
             if (isWrite == true)
             {
                 //m_dirty[setID][way] = 1;
-                uint8_t mask = 1 << way;
+                uint16_t mask = 1 << way;
                 m_dirty[setID] = m_dirty[setID] | (mask);
             }
             m_referenceCtr[setID][way]++;
@@ -447,8 +447,8 @@ bool LLC::installNewLine(intptr_t addr, int setID, intptr_t &evictedAddr, bool i
     int index = getReplacementIndex(addr, setID, setType, tid);
     //evictedAddr = m_tagArray[setID][index] * m_lineSz; //line to be kicked out
     evictedAddr = m_tagArray[setID][index]; //line to be kicked out
-    uint8_t mask = 1 << index;
-    uint8_t retVal = m_dirty[setID] & mask;
+    uint16_t mask = 1 << index;
+    uint16_t retVal = m_dirty[setID] & mask;
     assert(retVal == 0 || retVal == mask);
     if (evictedAddr == -1 * m_lineSz)
         assert(retVal == 0);

--- a/simulators/popt-8b/llc.h
+++ b/simulators/popt-8b/llc.h
@@ -70,7 +70,7 @@ class LLC
 
         /* tag store */
         intptr_t** m_tagArray; //[numSets][numWays];
-        uint8_t* m_dirty;
+        uint16_t* m_dirty;
         stat_t** m_referenceCtr; //keep track of no. of references between insertion & eviction
         PIN_LOCK* m_setLocks;  //[numSets]; //per-set lock
 


### PR DESCRIPTION
changed the type of all m_dirty variables from uint8_t to uint16_t. Also additinal changes for related computations, e.g. mask variables.